### PR TITLE
Simplify the inheritance tree of PlacelessSetup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
+sudo: false
 python:
     - 2.7
+    - pypy
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - zope-testrunner --test-path=src
 notifications:
     email: false
+cache: pip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,12 @@
 CHANGES
 =======
 
+3.11.0 (unreleased)
+-------------------
+
+- Pin dependency of zope.testbrowser to version 4 because this package
+  doesn't work with version 5.
+
 3.10.0 (2012-01-13)
 -------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include *.py
 include *.txt
 include buildout.cfg
+include tox.ini
+include .travis.yml
+
 recursive-include src *.request
 recursive-include src *.response
 recursive-include src *.txt

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,17 @@
 ##############################################################################
 """Setup for zope.app.testing package
 
-$Id$
+
 """
 import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 setup(name='zope.app.testing',
-      version = '3.9.1dev',
+      version='3.11.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Application Testing Support',
@@ -40,50 +41,59 @@ setup(name='zope.app.testing',
           + '\n\n' +
           read('CHANGES.txt')
           ),
-      keywords = "zope3 test testing setup functional",
-      classifiers = [
+      keywords="zope3 test testing setup functional",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: Zope Public License',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.app.testing',
+          'Framework :: Zope3',
+      ],
+      url="https://github.com/zopefoundation/zope.app.testing",
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope', 'zope.app'],
       extras_require=dict(test=[
-          'ZODB3',
+          'ZODB',
           'zope.app.zcmlfiles',
           'zope.login',
           'zope.publisher >= 3.12',
           'zope.securitypolicy',
-          ]),
-      install_requires=['setuptools',
-                        'zope.annotation',
-                        'zope.app.appsetup >= 3.11',
-                        'zope.processlifetime',
-                        'zope.app.debug',
-                        'zope.app.dependable',
-                        'zope.app.publication',
-                        # We need zope.component with the hooks module.
-                        'zope.component >= 3.8',
-                        'zope.container',
-                        'zope.i18n',
-                        'zope.interface',
-                        'zope.password',
-                        'zope.publisher',
-                        'zope.schema',
-                        'zope.security',
-                        'zope.site',
-                        'zope.testing',
-                        'zope.testbrowser >= 4',
-                        'zope.traversing',
-                        ],
-      include_package_data = True,
-      zip_safe = False,
-      )
+          'zope.testrunner',
+      ]),
+      install_requires=[
+          'setuptools',
+          'zope.annotation',
+          'zope.app.appsetup >= 3.11',
+          'zope.processlifetime',
+          'zope.app.debug',
+          'zope.app.dependable',
+          'zope.app.publication',
+          # We need zope.component with the hooks module.
+          'zope.component >= 3.8',
+          'zope.container',
+          'zope.i18n >= 4.3.0',
+          'zope.interface',
+          'zope.password',
+          'zope.publisher',
+          'zope.schema',
+          'zope.security',
+          'zope.site',
+          'zope.testing',
+          # zope.testbrowser version 5 has a new API and
+          # doesn't have the 'connection' module
+          'zope.testbrowser >=4,<5',
+          'zope.traversing',
+      ],
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/app/testing/placelesssetup.py
+++ b/src/zope/app/testing/placelesssetup.py
@@ -30,9 +30,9 @@ class PlacelessSetup(EventPlacelessSetup,
                      ContainerPlacelessSetup):
 
     def setUp(self, doctesttest=None):
+        I18nPlacelessSetup.setUp(self)
         EventPlacelessSetup.setUp(self)
         ContainerPlacelessSetup.setUp(self)
-        I18nPlacelessSetup.setUp(self)
 
         setUpPasswordManagers()
         ztapi.browserView(None, 'absolute_url', AbsoluteURL)

--- a/src/zope/app/testing/placelesssetup.py
+++ b/src/zope/app/testing/placelesssetup.py
@@ -13,10 +13,9 @@
 ##############################################################################
 """Unit test logic for setting up and tearing down basic infrastructure
 
-$Id$
+
 """
 from zope.schema.vocabulary import setVocabularyRegistry
-from zope.component.testing import PlacelessSetup as CAPlacelessSetup
 from zope.component.eventtesting import PlacelessSetup as EventPlacelessSetup
 from zope.i18n.testing import PlacelessSetup as I18nPlacelessSetup
 from zope.password.testing import setUpPasswordManagers
@@ -26,13 +25,11 @@ from zope.traversing.browser.absoluteurl import AbsoluteURL
 from zope.app.testing import ztapi
 from zope.container.testing import PlacelessSetup as ContainerPlacelessSetup
 
-class PlacelessSetup(CAPlacelessSetup,
-                     EventPlacelessSetup,
+class PlacelessSetup(EventPlacelessSetup,
                      I18nPlacelessSetup,
                      ContainerPlacelessSetup):
 
     def setUp(self, doctesttest=None):
-        CAPlacelessSetup.setUp(self)
         EventPlacelessSetup.setUp(self)
         ContainerPlacelessSetup.setUp(self)
         I18nPlacelessSetup.setUp(self)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+   py27,pypy
+
+[testenv]
+commands =
+    zope-testrunner --test-path=src []
+deps =
+    .[test]


### PR DESCRIPTION
zope.component.testing.PlacelessSetup is just another name for zope.testing.cleanup.CleanUp, which we inherit from zope.i18n's version. Including it manually lead to a MRO issue.

Fixes https://github.com/zopefoundation/zope.i18n/issues/30

Also pin zope.testbrowser to a compatible version, add a minimal tox.ini for testing, add Python version classifiers and add pypy.