### PR TITLE
Move the dependency on zope.testbrowser into an extra.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
+sudo: false
 python:
     - 2.7
+    - pypy
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - zope-testrunner --test-path=src
 notifications:
     email: false
+cache: pip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,14 @@
 CHANGES
 =======
 
+3.11.0 (unreleased)
+-------------------
+
+- Move the dependency on ``zope.testbrowser`` to a new 'testbrowser'
+  extra, where it is pinned to version 4. This package is not
+  compatible with version 5. If ``zope.testbrowser`` is not installed,
+  the ``zope.app.testing.testbrowser`` package will not be available.
+
 3.10.0 (2012-01-13)
 -------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include *.py
 include *.txt
 include buildout.cfg
+include tox.ini
+include .travis.yml
+
 recursive-include src *.request
 recursive-include src *.response
 recursive-include src *.txt

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,23 @@
 ##############################################################################
 """Setup for zope.app.testing package
 
-$Id$
+
 """
 import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
+
+TESTBROWSER_REQUIRES = [
+    # zope.testbrowser version 5 has a new API and
+    # doesn't have the 'connection' module
+    'zope.testbrowser >=4,<5',
+]
 
 setup(name='zope.app.testing',
-      version = '3.9.1dev',
+      version='3.11.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Application Testing Support',
@@ -40,50 +47,59 @@ setup(name='zope.app.testing',
           + '\n\n' +
           read('CHANGES.txt')
           ),
-      keywords = "zope3 test testing setup functional",
-      classifiers = [
+      keywords="zope3 test testing setup functional",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: Zope Public License',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.app.testing',
+          'Framework :: Zope3',
+      ],
+      url="https://github.com/zopefoundation/zope.app.testing",
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope', 'zope.app'],
-      extras_require=dict(test=[
-          'ZODB3',
-          'zope.app.zcmlfiles',
-          'zope.login',
-          'zope.publisher >= 3.12',
-          'zope.securitypolicy',
-          ]),
-      install_requires=['setuptools',
-                        'zope.annotation',
-                        'zope.app.appsetup >= 3.11',
-                        'zope.processlifetime',
-                        'zope.app.debug',
-                        'zope.app.dependable',
-                        'zope.app.publication',
-                        # We need zope.component with the hooks module.
-                        'zope.component >= 3.8',
-                        'zope.container',
-                        'zope.i18n',
-                        'zope.interface',
-                        'zope.password',
-                        'zope.publisher',
-                        'zope.schema',
-                        'zope.security',
-                        'zope.site',
-                        'zope.testing',
-                        'zope.testbrowser >= 4',
-                        'zope.traversing',
-                        ],
-      include_package_data = True,
-      zip_safe = False,
-      )
+      extras_require={
+          'test': [
+              'ZODB',
+              'zope.app.zcmlfiles',
+              'zope.login',
+              'zope.publisher >= 3.12',
+              'zope.securitypolicy',
+              'zope.testrunner',
+          ] + TESTBROWSER_REQUIRES,
+          'testbrowser': TESTBROWSER_REQUIRES,
+      },
+      install_requires=[
+          'setuptools',
+          'zope.annotation',
+          'zope.app.appsetup >= 3.11',
+          'zope.processlifetime',
+          'zope.app.debug',
+          'zope.app.dependable',
+          'zope.app.publication',
+          # We need zope.component with the hooks module.
+          'zope.component >= 3.8',
+          'zope.container',
+          'zope.i18n >= 4.3.0',
+          'zope.interface',
+          'zope.password',
+          'zope.publisher',
+          'zope.schema',
+          'zope.security',
+          'zope.site',
+          'zope.testing',
+          'zope.traversing',
+      ],
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/app/testing/placelesssetup.py
+++ b/src/zope/app/testing/placelesssetup.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """Unit test logic for setting up and tearing down basic infrastructure
 
-$Id$
+
 """
 from zope.schema.vocabulary import setVocabularyRegistry
 from zope.component.testing import PlacelessSetup as CAPlacelessSetup

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+   py27,pypy
+
+[testenv]
+commands =
+    zope-testrunner --test-path=src []
+deps =
+    .[test]


### PR DESCRIPTION
And pin it to a version that works with this package.

This came out of the discussion in #1.