### PR TITLE
fix tests for `multipart 1.1`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 5.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix tests for ``multipart 1.x``
+  (`#14 <https://github.com/zopefoundation/zope.app.testing/issues/14>`_).
 
 
 5.0 (2023-02-10)

--- a/src/zope/app/testing/doctest.rst
+++ b/src/zope/app/testing/doctest.rst
@@ -128,7 +128,7 @@ transaction before the HTTP request.
   >>> print(http(r"""
   ... POST /@@contents.html HTTP/1.1
   ... Authorization: Basic mgr:mgrpw
-  ... Content-Length: 73
+  ... Content-Length: 58
   ... Content-Type: application/x-www-form-urlencoded
   ...
   ... type_name=BrowserAdd__zope.site.folder.Folder&new_value=f1""",

--- a/src/zope/app/testing/xmlrpc.rst
+++ b/src/zope/app/testing/xmlrpc.rst
@@ -45,7 +45,7 @@ Now, we'll add some items to the root folder:
   >>> print(http(r"""
   ... POST /@@contents.html HTTP/1.1
   ... Authorization: Basic bWdyOm1ncnB3
-  ... Content-Length: 73
+  ... Content-Length: 58
   ... Content-Type: application/x-www-form-urlencoded
   ...
   ... type_name=BrowserAdd__zope.site.folder.Folder&new_value=f1"""))
@@ -55,7 +55,7 @@ Now, we'll add some items to the root folder:
   >>> print(http(r"""
   ... POST /@@contents.html HTTP/1.1
   ... Authorization: Basic bWdyOm1ncnB3
-  ... Content-Length: 73
+  ... Content-Length: 58
   ... Content-Type: application/x-www-form-urlencoded
   ...
   ... type_name=BrowserAdd__zope.site.folder.Folder&new_value=f2"""))


### PR DESCRIPTION
Fixes #14

`multipart 1.1` no longer accepts a too large `Content-Length` value. The PR fixes those values in the failing tests.